### PR TITLE
Add user activation token scope

### DIFF
--- a/models/auth/access_token_scope.go
+++ b/models/auth/access_token_scope.go
@@ -24,6 +24,7 @@ const (
 	AccessTokenScopeCategoryIssue
 	AccessTokenScopeCategoryRepository
 	AccessTokenScopeCategoryUser
+	AccessTokenScopeCategoryUserActivation
 )
 
 // AllAccessTokenScopeCategories contains all access token scope categories
@@ -37,6 +38,7 @@ var AllAccessTokenScopeCategories = []AccessTokenScopeCategory{
 	AccessTokenScopeCategoryIssue,
 	AccessTokenScopeCategoryRepository,
 	AccessTokenScopeCategoryUser,
+	AccessTokenScopeCategoryUserActivation,
 }
 
 // AccessTokenScopeLevel represents the access levels without a given scope category
@@ -82,6 +84,9 @@ const (
 
 	AccessTokenScopeReadUser  AccessTokenScope = "read:user"
 	AccessTokenScopeWriteUser AccessTokenScope = "write:user"
+
+	AccessTokenScopeReadUserActivation  AccessTokenScope = "read:user-activation"
+	AccessTokenScopeWriteUserActivation AccessTokenScope = "write:user-activation"
 )
 
 // accessTokenScopeBitmap represents a bitmap of access token scopes.
@@ -93,7 +98,7 @@ const (
 	accessTokenScopeAllBits accessTokenScopeBitmap = accessTokenScopeWriteActivityPubBits |
 		accessTokenScopeWriteAdminBits | accessTokenScopeWriteMiscBits | accessTokenScopeWriteNotificationBits |
 		accessTokenScopeWriteOrganizationBits | accessTokenScopeWritePackageBits | accessTokenScopeWriteIssueBits |
-		accessTokenScopeWriteRepositoryBits | accessTokenScopeWriteUserBits
+		accessTokenScopeWriteRepositoryBits | accessTokenScopeWriteUserBits | accessTokenScopeWriteUserActivationBits
 
 	accessTokenScopePublicOnlyBits accessTokenScopeBitmap = 1 << iota
 
@@ -124,6 +129,9 @@ const (
 	accessTokenScopeReadUserBits  accessTokenScopeBitmap = 1 << iota
 	accessTokenScopeWriteUserBits accessTokenScopeBitmap = 1<<iota | accessTokenScopeReadUserBits
 
+	accessTokenScopeReadUserActivationBits  accessTokenScopeBitmap = 1 << iota
+	accessTokenScopeWriteUserActivationBits accessTokenScopeBitmap = 1<<iota | accessTokenScopeReadUserActivationBits
+
 	// The current implementation only supports up to 64 token scopes.
 	// If we need to support > 64 scopes,
 	// refactoring the whole implementation in this file (and only this file) is needed.
@@ -142,55 +150,60 @@ var allAccessTokenScopes = []AccessTokenScope{
 	AccessTokenScopeWriteIssue, AccessTokenScopeReadIssue,
 	AccessTokenScopeWriteRepository, AccessTokenScopeReadRepository,
 	AccessTokenScopeWriteUser, AccessTokenScopeReadUser,
+	AccessTokenScopeWriteUserActivation, AccessTokenScopeReadUserActivation,
 }
 
 // allAccessTokenScopeBits contains all access token scopes.
 var allAccessTokenScopeBits = map[AccessTokenScope]accessTokenScopeBitmap{
-	AccessTokenScopeAll:               accessTokenScopeAllBits,
-	AccessTokenScopePublicOnly:        accessTokenScopePublicOnlyBits,
-	AccessTokenScopeReadActivityPub:   accessTokenScopeReadActivityPubBits,
-	AccessTokenScopeWriteActivityPub:  accessTokenScopeWriteActivityPubBits,
-	AccessTokenScopeReadAdmin:         accessTokenScopeReadAdminBits,
-	AccessTokenScopeWriteAdmin:        accessTokenScopeWriteAdminBits,
-	AccessTokenScopeReadMisc:          accessTokenScopeReadMiscBits,
-	AccessTokenScopeWriteMisc:         accessTokenScopeWriteMiscBits,
-	AccessTokenScopeReadNotification:  accessTokenScopeReadNotificationBits,
-	AccessTokenScopeWriteNotification: accessTokenScopeWriteNotificationBits,
-	AccessTokenScopeReadOrganization:  accessTokenScopeReadOrganizationBits,
-	AccessTokenScopeWriteOrganization: accessTokenScopeWriteOrganizationBits,
-	AccessTokenScopeReadPackage:       accessTokenScopeReadPackageBits,
-	AccessTokenScopeWritePackage:      accessTokenScopeWritePackageBits,
-	AccessTokenScopeReadIssue:         accessTokenScopeReadIssueBits,
-	AccessTokenScopeWriteIssue:        accessTokenScopeWriteIssueBits,
-	AccessTokenScopeReadRepository:    accessTokenScopeReadRepositoryBits,
-	AccessTokenScopeWriteRepository:   accessTokenScopeWriteRepositoryBits,
-	AccessTokenScopeReadUser:          accessTokenScopeReadUserBits,
-	AccessTokenScopeWriteUser:         accessTokenScopeWriteUserBits,
+	AccessTokenScopeAll:                 accessTokenScopeAllBits,
+	AccessTokenScopePublicOnly:          accessTokenScopePublicOnlyBits,
+	AccessTokenScopeReadActivityPub:     accessTokenScopeReadActivityPubBits,
+	AccessTokenScopeWriteActivityPub:    accessTokenScopeWriteActivityPubBits,
+	AccessTokenScopeReadAdmin:           accessTokenScopeReadAdminBits,
+	AccessTokenScopeWriteAdmin:          accessTokenScopeWriteAdminBits,
+	AccessTokenScopeReadMisc:            accessTokenScopeReadMiscBits,
+	AccessTokenScopeWriteMisc:           accessTokenScopeWriteMiscBits,
+	AccessTokenScopeReadNotification:    accessTokenScopeReadNotificationBits,
+	AccessTokenScopeWriteNotification:   accessTokenScopeWriteNotificationBits,
+	AccessTokenScopeReadOrganization:    accessTokenScopeReadOrganizationBits,
+	AccessTokenScopeWriteOrganization:   accessTokenScopeWriteOrganizationBits,
+	AccessTokenScopeReadPackage:         accessTokenScopeReadPackageBits,
+	AccessTokenScopeWritePackage:        accessTokenScopeWritePackageBits,
+	AccessTokenScopeReadIssue:           accessTokenScopeReadIssueBits,
+	AccessTokenScopeWriteIssue:          accessTokenScopeWriteIssueBits,
+	AccessTokenScopeReadRepository:      accessTokenScopeReadRepositoryBits,
+	AccessTokenScopeWriteRepository:     accessTokenScopeWriteRepositoryBits,
+	AccessTokenScopeReadUser:            accessTokenScopeReadUserBits,
+	AccessTokenScopeWriteUser:           accessTokenScopeWriteUserBits,
+	AccessTokenScopeReadUserActivation:  accessTokenScopeReadUserActivationBits,
+	AccessTokenScopeWriteUserActivation: accessTokenScopeWriteUserActivationBits,
 }
 
 // readAccessTokenScopes maps a scope category to the read permission scope
 var accessTokenScopes = map[AccessTokenScopeLevel]map[AccessTokenScopeCategory]AccessTokenScope{
 	Read: {
-		AccessTokenScopeCategoryActivityPub:  AccessTokenScopeReadActivityPub,
-		AccessTokenScopeCategoryAdmin:        AccessTokenScopeReadAdmin,
-		AccessTokenScopeCategoryMisc:         AccessTokenScopeReadMisc,
-		AccessTokenScopeCategoryNotification: AccessTokenScopeReadNotification,
-		AccessTokenScopeCategoryOrganization: AccessTokenScopeReadOrganization,
-		AccessTokenScopeCategoryPackage:      AccessTokenScopeReadPackage,
-		AccessTokenScopeCategoryIssue:        AccessTokenScopeReadIssue,
-		AccessTokenScopeCategoryRepository:   AccessTokenScopeReadRepository,
-		AccessTokenScopeCategoryUser:         AccessTokenScopeReadUser,
+		AccessTokenScopeCategoryActivityPub:    AccessTokenScopeReadActivityPub,
+		AccessTokenScopeCategoryAdmin:          AccessTokenScopeReadAdmin,
+		AccessTokenScopeCategoryMisc:           AccessTokenScopeReadMisc,
+		AccessTokenScopeCategoryNotification:   AccessTokenScopeReadNotification,
+		AccessTokenScopeCategoryOrganization:   AccessTokenScopeReadOrganization,
+		AccessTokenScopeCategoryPackage:        AccessTokenScopeReadPackage,
+		AccessTokenScopeCategoryIssue:          AccessTokenScopeReadIssue,
+		AccessTokenScopeCategoryRepository:     AccessTokenScopeReadRepository,
+		AccessTokenScopeCategoryUser:           AccessTokenScopeReadUser,
+		AccessTokenScopeCategoryUserActivation: AccessTokenScopeReadUserActivation,
 	},
 	Write: {
-		AccessTokenScopeCategoryActivityPub:  AccessTokenScopeWriteActivityPub,
-		AccessTokenScopeCategoryAdmin:        AccessTokenScopeWriteAdmin,
-		AccessTokenScopeCategoryMisc:         AccessTokenScopeWriteMisc,
-		AccessTokenScopeCategoryNotification: AccessTokenScopeWriteNotification,
-		AccessTokenScopeCategoryOrganization: AccessTokenScopeWriteOrganization,
-		AccessTokenScopeCategoryPackage:      AccessTokenScopeWritePackage,
-		AccessTokenScopeCategoryIssue:        AccessTokenScopeWriteIssue,
-		AccessTokenScopeCategoryRepository:   AccessTokenScopeWriteRepository,
-		AccessTokenScopeCategoryUser:         AccessTokenScopeWriteUser,
+		AccessTokenScopeCategoryActivityPub:    AccessTokenScopeWriteActivityPub,
+		AccessTokenScopeCategoryAdmin:          AccessTokenScopeWriteAdmin,
+		AccessTokenScopeCategoryMisc:           AccessTokenScopeWriteMisc,
+		AccessTokenScopeCategoryNotification:   AccessTokenScopeWriteNotification,
+		AccessTokenScopeCategoryOrganization:   AccessTokenScopeWriteOrganization,
+		AccessTokenScopeCategoryPackage:        AccessTokenScopeWritePackage,
+		AccessTokenScopeCategoryIssue:          AccessTokenScopeWriteIssue,
+		AccessTokenScopeCategoryRepository:     AccessTokenScopeWriteRepository,
+		AccessTokenScopeCategoryUser:           AccessTokenScopeWriteUser,
+		AccessTokenScopeCategoryUserActivation: AccessTokenScopeWriteUserActivation,
 	},
 }
 

--- a/modules/structs/admin_user.go
+++ b/modules/structs/admin_user.go
@@ -57,3 +57,8 @@ type EditUserOption struct {
 	Restricted              *bool   `json:"restricted"`
 	Visibility              string  `json:"visibility" binding:"In(,public,limited,private)"`
 }
+
+// ChangeUserActivationOption sets user's active state
+type ChangeUserActivationOption struct {
+	Active bool `json:"active"`
+}

--- a/routers/api/v1/admin/user.go
+++ b/routers/api/v1/admin/user.go
@@ -490,3 +490,28 @@ func RenameUser(ctx *context.APIContext) {
 	}
 	ctx.Status(http.StatusNoContent)
 }
+
+// ChangeUserActive sets the active state of a user
+func ChangeUserActive(ctx *context.APIContext) {
+	if ctx.ContextUser.IsOrganization() {
+		ctx.APIError(http.StatusUnprocessableEntity, fmt.Errorf("%s is an organization not a user", ctx.ContextUser.Name))
+		return
+	}
+
+	active := web.GetForm(ctx).(*api.ChangeUserActivationOption).Active
+
+	opts := &user_service.UpdateOptions{
+		IsActive: optional.Some(active),
+	}
+
+	if err := user_service.UpdateUser(ctx, ctx.ContextUser, opts); err != nil {
+		if user_model.IsErrDeleteLastAdminUser(err) {
+			ctx.APIError(http.StatusBadRequest, err)
+		} else {
+			ctx.APIErrorInternal(err)
+		}
+		return
+	}
+
+	ctx.JSON(http.StatusOK, convert.ToUser(ctx, ctx.ContextUser, ctx.Doer))
+}

--- a/routers/api/v1/admin/user.go
+++ b/routers/api/v1/admin/user.go
@@ -194,6 +194,23 @@ func EditUser(ctx *context.APIContext) {
 
 	form := web.GetForm(ctx).(*api.EditUserOption)
 
+	if form.Active != nil && ctx.Data["IsApiToken"] == true {
+		scope, ok := ctx.Data["ApiTokenScope"].(auth.AccessTokenScope)
+		if ok {
+			requiredScopes := auth.GetRequiredScopes(auth.Write, auth.AccessTokenScopeCategoryUserActivation)
+			allow, err := scope.HasScope(requiredScopes...)
+			if err != nil {
+				ctx.APIError(http.StatusForbidden, "checking scope failed: "+err.Error())
+				return
+			}
+
+			if !allow {
+				ctx.APIError(http.StatusForbidden, fmt.Sprintf("token does not have at least one of required scope(s), required=%v, token scope=%v", requiredScopes, scope))
+				return
+			}
+		}
+	}
+
 	authOpts := &user_service.UpdateAuthOptions{
 		LoginSource:        optional.FromNonDefault(form.SourceID),
 		LoginName:          optional.Some(form.LoginName),

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -1765,6 +1765,10 @@ func Routes() *web.Router {
 			})
 		}, tokenRequiresScopes(auth_model.AccessTokenScopeCategoryAdmin), reqToken(), reqSiteAdmin())
 
+		m.Group("/admin/users", func() {
+			m.Patch("/{username}/active", bind(api.ChangeUserActivationOption{}), admin.ChangeUserActive)
+		}, tokenRequiresScopes(auth_model.AccessTokenScopeCategoryUserActivation), reqToken(), reqSiteAdmin(), context.UserAssignmentAPI())
+
 		m.Group("/topics", func() {
 			m.Get("/search", repo.TopicSearch)
 		}, tokenRequiresScopes(auth_model.AccessTokenScopeCategoryRepository))

--- a/routers/api/v1/api.go
+++ b/routers/api/v1/api.go
@@ -1713,8 +1713,13 @@ func Routes() *web.Router {
 			m.Group("/cron", func() {
 				m.Get("", admin.ListCronTasks)
 				m.Post("/{task}", admin.PostCronTask)
-			})
-			m.Get("/orgs", admin.GetAllOrgs)
+			}, tokenRequiresScopes(auth_model.AccessTokenScopeCategoryAdmin))
+			m.Get("/orgs", tokenRequiresScopes(auth_model.AccessTokenScopeCategoryAdmin), admin.GetAllOrgs)
+			m.Patch("/users/{username}/active",
+				tokenRequiresScopes(auth_model.AccessTokenScopeCategoryUserActivation),
+				context.UserAssignmentAPI(),
+				bind(api.ChangeUserActivationOption{}),
+				admin.ChangeUserActive)
 			m.Group("/users", func() {
 				m.Get("", admin.SearchUsers)
 				m.Post("", bind(api.CreateUserOption{}), admin.CreateUser)
@@ -1733,23 +1738,23 @@ func Routes() *web.Router {
 					m.Post("/badges", bind(api.UserBadgeOption{}), admin.AddUserBadges)
 					m.Delete("/badges", bind(api.UserBadgeOption{}), admin.DeleteUserBadges)
 				}, context.UserAssignmentAPI())
-			})
+			}, tokenRequiresScopes(auth_model.AccessTokenScopeCategoryAdmin))
 			m.Group("/emails", func() {
 				m.Get("", admin.GetAllEmails)
 				m.Get("/search", admin.SearchEmail)
-			})
+			}, tokenRequiresScopes(auth_model.AccessTokenScopeCategoryAdmin))
 			m.Group("/unadopted", func() {
 				m.Get("", admin.ListUnadoptedRepositories)
 				m.Post("/{username}/{reponame}", admin.AdoptRepository)
 				m.Delete("/{username}/{reponame}", admin.DeleteUnadoptedRepository)
-			})
+			}, tokenRequiresScopes(auth_model.AccessTokenScopeCategoryAdmin))
 			m.Group("/hooks", func() {
 				m.Combo("").Get(admin.ListHooks).
 					Post(bind(api.CreateHookOption{}), admin.CreateHook)
 				m.Combo("/{id}").Get(admin.GetHook).
 					Patch(bind(api.EditHookOption{}), admin.EditHook).
 					Delete(admin.DeleteHook)
-			})
+			}, tokenRequiresScopes(auth_model.AccessTokenScopeCategoryAdmin))
 			m.Group("/actions", func() {
 				m.Group("/runners", func() {
 					m.Get("", admin.ListRunners)
@@ -1759,15 +1764,11 @@ func Routes() *web.Router {
 				})
 				m.Get("/runs", admin.ListWorkflowRuns)
 				m.Get("/jobs", admin.ListWorkflowJobs)
-			})
+			}, tokenRequiresScopes(auth_model.AccessTokenScopeCategoryAdmin))
 			m.Group("/runners", func() {
 				m.Get("/registration-token", admin.GetRegistrationToken)
-			})
-		}, tokenRequiresScopes(auth_model.AccessTokenScopeCategoryAdmin), reqToken(), reqSiteAdmin())
-
-		m.Group("/admin/users", func() {
-			m.Patch("/{username}/active", bind(api.ChangeUserActivationOption{}), admin.ChangeUserActive)
-		}, tokenRequiresScopes(auth_model.AccessTokenScopeCategoryUserActivation), reqToken(), reqSiteAdmin(), context.UserAssignmentAPI())
+			}, tokenRequiresScopes(auth_model.AccessTokenScopeCategoryAdmin))
+		}, reqToken(), reqSiteAdmin())
 
 		m.Group("/topics", func() {
 			m.Get("/search", repo.TopicSearch)


### PR DESCRIPTION
## Summary
- add new AccessToken scope `write:user-activation`
- expose a dedicated admin API route to toggle user activation
- support assigning this permission to API tokens

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_688af84262b4832d8d13ecc664a9fac4